### PR TITLE
ChainMatrixを用いたJointの結合を行える機能の追加

### DIFF
--- a/ec_calculator/include/ec_calculator/eigenUtility.h
+++ b/ec_calculator/include/ec_calculator/eigenUtility.h
@@ -1,5 +1,5 @@
-#ifndef EIGEN_UTILITY_H
-#define EIGEN_UTILITY_H
+#ifndef EC_CALCULATOR_EIGEN_UTILITY_H
+#define EC_CALCULATOR_EIGEN_UTILITY_H
 
 #include <string>
 

--- a/ec_calculator/include/ec_calculator/joint.h
+++ b/ec_calculator/include/ec_calculator/joint.h
@@ -16,13 +16,14 @@ namespace ec_calculator
     class Joint
     {
         private:
-            // Family
-            int _joint_index = 0;
-            std::string _joint_name;
-            Joint* _parent_joint = nullptr;
-            std::vector<Joint*> _children_joint{nullptr};
-            int _children_number = 0;
+            int _index = 0;
+            std::string _name = "";
 
+            // Family
+            Joint* _parent = nullptr;
+            std::vector<Joint*> _children { nullptr };
+
+            /*
             // Parameter
             Eigen::Matrix<double, 3, 1> _q, _v, _w;
             Eigen::Matrix<double, 6, 1> _xi;
@@ -36,8 +37,30 @@ namespace ec_calculator
             Eigen::Matrix<double, 6, 1> _xi_dagger;
 
             int _minimum_joint;
+            */
 
         public:
+
+            // Constructor
+            Joint();
+
+            // Initialize
+            void init(const int index, const std::string name);
+
+            // Chain Management Functions
+            void setParent(Joint &parent);
+            bool addChild(Joint &child);
+            void clearChildren();
+
+            // Properties
+            int getIndex();
+            std::string getName();
+
+            // Debug
+            std::string getChildrenList();
+            std::string getChildrenList(const int tab);
+
+            /*
             // Constructor
             Joint();
 
@@ -64,6 +87,7 @@ namespace ec_calculator
                 Eigen::Matrix<double, 4, 4> getChildrenExpXiHatThetaRecursion();
 
             Eigen::Matrix<double, 6, 1> getXiDagger(const int &chain_, const int &joint_);
+            */
     };
 }
 

--- a/ec_calculator/include/ec_calculator/joint.h
+++ b/ec_calculator/include/ec_calculator/joint.h
@@ -1,4 +1,4 @@
-#ifndef JOINT_H
+#ifndef EC_CALCULATOR_JOINT_H
 
 #include <iostream>
 #include <string>
@@ -91,5 +91,5 @@ namespace ec_calculator
     };
 }
 
-#define JOINT_H
+#define EC_CALCULATOR_JOINT_H
 #endif

--- a/ec_calculator/include/ec_calculator/joint.h
+++ b/ec_calculator/include/ec_calculator/joint.h
@@ -1,16 +1,5 @@
 #ifndef JOINT_H
 
-#include <ros/ros.h>
-
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2_ros/transform_broadcaster.h>
-#include <geometry_msgs/TransformStamped.h>
-
-#include <std_msgs/Bool.h>
-#include <std_msgs/Int16.h>
-#include <geometry_msgs/Pose.h>
-#include <std_msgs/Float32MultiArray.h>
-
 #include <iostream>
 #include <string>
 #include <fstream>

--- a/ec_calculator/include/ec_calculator/manipulator.h
+++ b/ec_calculator/include/ec_calculator/manipulator.h
@@ -2,15 +2,28 @@
 
 #include "joint.h"
 
+#ifndef JOINT_NUM
+#define JOINT_NUM 10
+#endif
+
+#ifndef CHAIN_NUM
+#define CHAIN_NUM 3
+#endif
+
 namespace ec_calculator
 {
     class Manipulator
     {
         private:
-            Joint _joint;
+            Joint _joints[JOINT_NUM];
 
         public:
-            void print();
+            void init();
+            bool setChainMatrix(Eigen::Matrix<bool, CHAIN_NUM, JOINT_NUM> chain_mat);
+            
+            Joint getJoint(int index);
+
+            void printTree();
     };
 }
 

--- a/ec_calculator/include/ec_calculator/manipulator.h
+++ b/ec_calculator/include/ec_calculator/manipulator.h
@@ -1,4 +1,4 @@
-#ifndef MANIPULATOR_H
+#ifndef EC_CALCULATOR_MANIPULATOR_H
 
 #include "joint.h"
 
@@ -27,5 +27,5 @@ namespace ec_calculator
     };
 }
 
-#define MANIPULATOR_H
+#define EC_CALCULATOR_MANIPULATOR_H
 #endif

--- a/ec_calculator/include/ec_calculator/manipulator_tf_publisher.h
+++ b/ec_calculator/include/ec_calculator/manipulator_tf_publisher.h
@@ -1,4 +1,4 @@
-#ifndef MANIPULATOR_TF_PUBLISHER_H
+#ifndef EC_CALCULATOR_MANIPULATOR_TF_PUBLISHER_H
 
 #include "ec_calculator/manipulator.h"
 
@@ -16,5 +16,5 @@ namespace ec_calculator
     };
 }
 
-#define MANIPULATOR_TF_PUBLISHER_H
+#define EC_CALCULATOR_MANIPULATOR_TF_PUBLISHER_H
 #endif

--- a/ec_calculator/src/joint.cpp
+++ b/ec_calculator/src/joint.cpp
@@ -5,6 +5,71 @@ namespace ec_calculator
 {
     Joint::Joint()
     {
+
+    }
+
+    void Joint::init(const int index, const std::string name)
+    {
+        _index = index;
+        _name = name;
+        clearChildren();
+    }
+
+    void Joint::setParent(Joint &parent)
+    {
+        _parent = &parent;
+    }
+
+    bool Joint::addChild(Joint &child)
+    {
+        if(std::find(_children.begin(), _children.end(), &child) != _children.end()) return false;
+        _children.push_back(&child);
+        return true;
+    }
+
+    void Joint::clearChildren()
+    {
+        _children.clear();
+    }
+
+    int Joint::getIndex()
+    {
+        return _index;
+    }
+    
+    std::string Joint::getName()
+    {
+        return _name;
+    }
+
+    std::string Joint::getChildrenList()
+    {
+        std::cout << "\nTree:" << std::endl;
+        return getChildrenList(0);
+    }
+
+    std::string Joint::getChildrenList(const int tab)
+    {
+        std::string tree = std::to_string(_index);
+        if(_children.size() == 0) return tree;
+        tree += " --->\t";
+        tree += _children[0]->getChildrenList(tab);
+        if(_children.size() == 1) tree += "\n";
+        for(int child = 1; child < _children.size(); child++)
+        {
+            for(int t = 0; t <= tab; t++)
+            {
+                tree += "\t";
+            }
+            tree += _children[child]->getChildrenList(tab);
+        }
+
+        return tree;
+    }
+
+    /*
+    Joint::Joint()
+    {
         updateTheta(_theta);
     }
 
@@ -173,4 +238,5 @@ namespace ec_calculator
 
         return _parent_joint->getChildrenExpXiHatThetaRecursion()*getExpXiHatTheta();
     }
+    */
 }

--- a/ec_calculator/src/manipulator.cpp
+++ b/ec_calculator/src/manipulator.cpp
@@ -2,8 +2,44 @@
 
 namespace ec_calculator
 {
-    void Manipulator::print()
+    void Manipulator::init()
     {
-        // _joint.print();
+        for(int index = 0; index < JOINT_NUM; index++)
+        {
+            _joints[index].init(index, "Joint" + std::to_string(index));
+        }
+    }
+
+    bool Manipulator::setChainMatrix(Eigen::Matrix<bool, CHAIN_NUM, JOINT_NUM> chain_mat)
+    {
+        std::cout << "\nSetChainMatrix:" << std::endl;
+        for(int chain = 0; chain < CHAIN_NUM; chain++)
+        {
+            int parent = -1;
+            for(int child = 0; child < JOINT_NUM; child++)
+            {
+                if(!chain_mat(chain, child)) continue;
+                if(parent != -1)
+                {
+                    _joints[child].setParent(_joints[parent]);
+                    if(_joints[parent].addChild(_joints[child]))
+                    {
+                        /* Debug */
+                        std::cout << _joints[child].getName() << " is set as child of " << _joints[parent].getName() << std::endl;
+                    }
+                }
+                parent = child;
+            }
+        }
+    }
+
+    Joint Manipulator::getJoint(int index)
+    {
+        return _joints[index];
+    }
+
+    void Manipulator::printTree()
+    {
+        std::cout << _joints[0].getChildrenList() << std::endl;
     }
 }

--- a/ec_calculator/src/nodes/ec_calculator_node.cpp
+++ b/ec_calculator/src/nodes/ec_calculator_node.cpp
@@ -1,3 +1,11 @@
+#ifndef JOINT_NUM
+#define JOINT_NUM 10
+#endif
+
+#ifndef CHAIN_NUM
+#define CHAIN_NUM 3
+#endif
+
 #include "ec_calculator/manipulator.h"
 #include "ec_calculator/manipulator_tf_publisher.h"
 
@@ -12,6 +20,18 @@ int main(int argc, char **argv)
 
     Manipulator manip;
     ManipulatorTFPublisher tfPublisher(manip);
+
+    manip.init();
+
+    Eigen::Matrix<bool, CHAIN_NUM, JOINT_NUM> chain_matrix;
+    chain_matrix <<
+    // 1  2  3  4  5  6  7  8  9 10
+    1, 1, 1, 0, 0, 1, 0, 0, 1, 0,
+    1, 1, 0, 1, 0, 0, 1, 0, 0, 1,
+    1, 1, 0, 0, 1, 0, 0, 1, 0, 0;
+    manip.setChainMatrix(chain_matrix);
+
+    manip.printTree();
 
     while(nh.ok())
     {


### PR DESCRIPTION
## Manipulatorクラス
* ChainMatrixを用いてJoint同士を設定する関数の追加
* マニピュレータの構造をコンソールに表示する関数の追加
## Jointクラス
* 一部のメンバをコメントアウト(特に複雑な意図はないので必要に応じて戻してOK)
* 使用していないIncludeを削除
* 子ジョイントのリストを作成する関数の追加
## ec_calculator_node
* 追加した機能をテストするように変更
## その他
* インクルードガードの修正
インクルードガードに使用する文字列に名前空間を含むように変更