### PR TITLE
Topic通信を追加しました

### DIFF
--- a/ec_calculator/include/ec_calculator/eigenUtility.h
+++ b/ec_calculator/include/ec_calculator/eigenUtility.h
@@ -2,6 +2,7 @@
 #define EC_CALCULATOR_EIGEN_UTILITY_H
 
 #include <string>
+#include <vector>
 
 #include <Eigen/Core>
 #include <Eigen/LU>
@@ -194,6 +195,34 @@ namespace ec_calculator
                     +cos(euler(2,0))*cos(euler(1,0)),   -sin(euler(2,0)),   +0.0;
 
                 return trans_euler_;
+            }
+
+            Eigen::Matrix<double, -1, 1> array2Matrix(const std::vector<float> &array_)
+            {
+                Eigen::Matrix<double, -1, 1> matrix_;
+                int size_ = array_.size();
+                matrix_.resize(size_, 1);
+
+                for(int index = 0; index < size_; index++)
+                {
+                    matrix_(index, 0) = array_[index];
+                }
+
+                return matrix_;
+            }
+
+            std::vector<float> matrix2Array(const Eigen::Matrix<double, -1, 1> &matrix_)
+            {
+                std::vector<float> array_;
+                int size_ = matrix_.rows();
+                array_.resize(size_);
+
+                for(int index = 0; index < size_; index++)
+                {
+                    array_[index] = matrix_(index, 0);
+                }
+
+                return array_;
             }
     };
 }

--- a/ec_calculator/include/ec_calculator/manipulator.h
+++ b/ec_calculator/include/ec_calculator/manipulator.h
@@ -20,9 +20,14 @@ namespace ec_calculator
 
             // Parameters
             Eigen::Matrix<double, -1, 1> _angle;
-            // Eigen::Matrix<double, -1, 1> _target_angle;
+            Eigen::Matrix<double, -1, 1> _target_angle;
             Eigen::Matrix<double, -1, 1> _angular_velocity;
             Eigen::Matrix<double, -1, 1> _target_angular_velocity;
+            int _start_joint = 0, _end_joint = 0;
+            Eigen::Matrix<double, 6, 1> _target_pose;
+            bool _ec_enable = false;
+            bool _emergency_stop = false;
+            bool _motor_enable = false;
 
             // Time
             std::chrono::system_clock::time_point _start_time, _end_time;
@@ -32,6 +37,7 @@ namespace ec_calculator
         public:
             // Initialize
             void init(Model* model_);
+                void clearParameters();
                 bool setChainMatrix(const Eigen::Matrix<bool, -1, -1> &chain_matrix);
                 void setJointParameters();
                     void setTipIndex(const int &tip_index_);
@@ -55,12 +61,22 @@ namespace ec_calculator
 
             // Angle Command
             Eigen::Matrix<double, -1, 1> getAngularVelocityByAngle(const Eigen::Matrix<double, -1, 1> &target_angle_);
+            Eigen::Matrix<double, -1, 1> getAngularVelocityByAngle();
 
             // Inverse Kinematics
-            Eigen::Matrix<double, -1, 1> getAngularVelocityByEC(const int &start_joint_index_, const int &end_joint_index_, const Eigen::Matrix<double, 6, 1> target_velocity_);
+            void setJointPosition(const int &start_joint_index_, const int &end_joint_index_, const Eigen::Matrix<double, 6, 1> target_velocity_);
+            void setJointVelocity(const int &start_joint_index_, const int &end_joint_index_, const Eigen::Matrix<double, 6, 1> target_velocity_);
+            Eigen::Matrix<double, -1, 1> getAngularVelocityByEC();
 
             // Angular Velocity to Angle (for Visualization)
             Eigen::Matrix<double, -1, 1> angularVelocity2Angle(const Eigen::Matrix<double, -1, 1> &angular_velocity_);
+
+            // Subscriber
+            void setECEnable(const bool &ec_enable_);
+            void setEmergencyStop(const bool &emergency_stop_);
+            void setMotorEnable(const bool &motor_enable_);
+            void setTargetAngle(const Eigen::Matrix<double, -1, 1> &target_angle_);
+            void setTargetPose(const Eigen::Matrix<double, -1, 1> &target_pose_);    // 2: start_joint, end_joint, 6: 3position, 3orientation
 
             // Debug
             void printTree();

--- a/ec_calculator/include/ec_calculator/manipulator_tf_publisher.h
+++ b/ec_calculator/include/ec_calculator/manipulator_tf_publisher.h
@@ -2,8 +2,6 @@
 
 #include "ec_calculator/manipulator.h"
 
-#include <iostream>
-
 #include <tf/transform_broadcaster.h>
 
 namespace ec_calculator

--- a/ec_calculator/launch/ec_calculator.launch
+++ b/ec_calculator/launch/ec_calculator.launch
@@ -1,0 +1,5 @@
+<launch>
+
+    <node name="ec_calculator" pkg="ec_calculator" type="ec_calculator_node" output="screen"/>
+
+</launch>

--- a/ec_calculator/src/joint.cpp
+++ b/ec_calculator/src/joint.cpp
@@ -6,7 +6,7 @@ namespace ec_calculator
     // Constructor
     Joint::Joint()
     {
-        updateTheta(_theta);
+        updateTheta(0.0);
     }
 
     // Initialize

--- a/ec_calculator/src/manipulator.cpp
+++ b/ec_calculator/src/manipulator.cpp
@@ -260,15 +260,13 @@ namespace ec_calculator
 
     void Manipulator::print()
     {
-        // for(int i = 0; i < _tip_index.size(); i++)
-        // {
-        //     std::cout << "joint" << _tip_index[i] << ":   " << getPose(_tip_index[i]).transpose() << std::endl;
-        // }
-        // std::cout << std::endl;
-
-        std::cout << _ec_enable << "  " << _emergency_stop << "  " << _motor_enable << std::endl
-        << _target_angle.transpose() << std::endl
-        << _start_joint << "  " << _end_joint << std::endl
-        <<  _target_pose.transpose() << std::endl << std::endl;
+        std::cout << "\n\nrqt の topic publisher で以下の情報を送信してください.\ntarget angle のみ rviz に反映されます.\n\n";
+        std::cout << "ec enable: " << _ec_enable << std::endl;
+        std::cout << "emergency stop: " << _emergency_stop << std::endl;
+        std::cout << "motor enable: " << _motor_enable << std::endl;
+        std::cout << "target angle: " << _target_angle.transpose() << std::endl;
+        std::cout << "start joint: " << _start_joint << std::endl;
+        std::cout << "end joint: " << _end_joint << std::endl;
+        std::cout << "target pose" <<  _target_pose.transpose() << std::endl << std::endl;
     }
 }

--- a/ec_calculator/src/manipulator_tf_publisher.cpp
+++ b/ec_calculator/src/manipulator_tf_publisher.cpp
@@ -32,6 +32,11 @@ namespace ec_calculator
 
             br.sendTransform(transform_stamped);
         }
+
+        for(int tip = 0; tip < _manipulator->getChainNum(); tip++)
+        {
+            publish(_manipulator->getJointParentName(0), ("pose" + std::to_string(tip)), _manipulator->getPose(_manipulator->getJointNum()+tip));
+        }
     }
 
     void ManipulatorTFPublisher::publish(const std::string &base_name_, const std::string &point_name_, const Eigen::Matrix<double, 6, 1> &pose_)

--- a/ec_calculator/src/manipulator_tf_publisher.cpp
+++ b/ec_calculator/src/manipulator_tf_publisher.cpp
@@ -54,7 +54,5 @@ namespace ec_calculator
         transform_stamped.transform.rotation.w = q.w();
 
         br.sendTransform(transform_stamped);
-
-        std::cout << pose_.transpose() << std::endl << std::endl;
     }
 }

--- a/ec_calculator/src/nodes/ec_calculator_node.cpp
+++ b/ec_calculator/src/nodes/ec_calculator_node.cpp
@@ -49,7 +49,7 @@ void target_pose_cb(std_msgs::Float32MultiArray::ConstPtr msg)
 
 int main(int argc, char **argv)
 {
-    ros::init(argc, argv, "ECCalculator");
+    ros::init(argc, argv, "ec_calculator");
     ros::NodeHandle nh;
     double rate = 10.0;
     ros::Rate loop_rate(rate);
@@ -81,15 +81,18 @@ int main(int argc, char **argv)
     1, 0, 0, 0, 0, 0, 1;
     Eigen::Matrix<double, 3, 11> joi_po;
     joi_po <<
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1,
     0, 0, 0, 0, 1, 2, 3, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
     Eigen::Matrix<double, 3, 7> tra;
-    tra.setZero();
+    tra <<
+    0, 1, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0;
     Eigen::Matrix<double, 3, 7> rot;
     rot <<
-    0, 0, 0, 1, 0, 0, 0,
-    0, 1, 0, 0, 0, 1, 0,
+    0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 1, 0, 1, 0,
     1, 0, 1, 0, 1, 0, 1;
     Eigen::Matrix<double, 7, 7> a2a_ga;
     a2a_ga.setIdentity();

--- a/ec_calculator/src/nodes/ec_calculator_node.cpp
+++ b/ec_calculator/src/nodes/ec_calculator_node.cpp
@@ -110,11 +110,6 @@ int main(int argc, char **argv)
 
         manip.angularVelocity2Angle(manip.getAngularVelocityByAngle());    // callBack(){manip.setAngle(msg);} while(){pub.publish(manip.getAngularVelocity());}
 
-        for(int i = 0; i < manip.getChainNum(); i++)
-        {
-            tfPublisher.publish("manipulator_base_link", ("pose"+std::to_string(i)), manip.getPose(manip.getJointNum()+i));
-        }
-
         angular_velocity.data = EigenUtility.matrix2Array(manip.getAngularVelocityByAngle());
         angular_velocity_pub.publish(angular_velocity);
 


### PR DESCRIPTION
```
rqt の topic publisher で以下の情報を送信してください.
target angle のみ rviz に反映されます.

※ Tool i は先端の仮想 joint です．
※ Pose i は順運動学の結果を rviz 上に表示したものです．
※ Joint 1 のみ並進関節です．
```

### ec_enable
- std_msgs::Bool
- 角度指令モードと位置姿勢指令モードの切り替え
- true : 位置姿勢指令(逆運動学)
- false : 角度指令

### emergency_stop
- std_msgs::Bool
- true : 緊急停止
- false : 影響なし

### motor_enable
- std_msgs::Bool
- true : モータを動かす
- false : rvizのみ動かす

### target_angle
- std_msgs::Float32MultiArray
- size : JOINT_NUM
- target_angle[i] : 第 i 関節の目標角度(並進の場合目標変位)

### target_pose

- std_msgs::Float32MultiArray
- size : 8
- target_pose[0] : start_joint
- target_pose[1] : end joint
- target_pose[2,3,4] : target x, y, z
- target_pose[5,6,7] : target Euler angle z, y, x