### PR TITLE
逆運動学

### DIFF
--- a/ec_calculator/CMakeLists.txt
+++ b/ec_calculator/CMakeLists.txt
@@ -157,11 +157,12 @@ set(HEADERS include/ec_calculator/eigenUtility.h)
 add_executable(eigenUtility_example src/examples/eigenUtility_example)
 target_link_libraries(eigenUtility_example ${catkin_LIBRARIES})
 
+set(HEADERS include/ec_calculator/interpolation.h)
 set(HEADERS include/ec_calculator/model.h)
 set(HEADERS include/ec_calculator/joint.h)
 set(HEADERS include/ec_calculator/manipulator.h)
 set(HEADERS include/ec_calculator/manipulator_tf_publisher.h)
-add_executable(ec_calculator_node src/model src/joint src/manipulator src/manipulator_tf_publisher src/nodes/ec_calculator_node)
+add_executable(ec_calculator_node src/interpolation src/model src/joint src/manipulator src/manipulator_tf_publisher src/nodes/ec_calculator_node)
 target_link_libraries(ec_calculator_node ${catkin_LIBRARIES} "/usr/include/eigen3")
 
 #############

--- a/ec_calculator/include/ec_calculator/eigenUtility.h
+++ b/ec_calculator/include/ec_calculator/eigenUtility.h
@@ -186,6 +186,16 @@ namespace ec_calculator
                 return adjoint_inv_mat_;
             }
 
+            Eigen::Matrix<double, 6, 6> getTransformationMatrix(const Eigen::Matrix<double, 4, 4> &homogeneous_trans_mat)
+            {
+                Eigen::Matrix<double, 6, 6> transformation_mat_;
+                transformation_mat_ <<
+                    homogeneous_trans_mat.block(0, 0, 3, 3).transpose(), Eigen::Matrix<double, 3, 3>::Zero(),
+                    Eigen::Matrix<double, 3, 3>::Zero(), getTransformationEuler(getPose(homogeneous_trans_mat).block(3, 0, 3, 1));
+
+                return transformation_mat_;
+            }
+
             Eigen::Matrix<double, 3, 3> getTransformationEuler(const Eigen::Matrix<double, 3, 1> &euler)
             {
                 Eigen::Matrix<double, 3, 3> trans_euler_;

--- a/ec_calculator/include/ec_calculator/interpolation.h
+++ b/ec_calculator/include/ec_calculator/interpolation.h
@@ -22,7 +22,7 @@ namespace ec_calculator
 
             double _distance;
             double _during_time;
-            double _linear_velocity = 1;  // [m/s]
+            double _linear_velocity = 0.5;  // [m/s]
             double _sigmoid_gain = 1;
 
         public:

--- a/ec_calculator/include/ec_calculator/interpolation.h
+++ b/ec_calculator/include/ec_calculator/interpolation.h
@@ -22,8 +22,8 @@ namespace ec_calculator
 
             double _distance;
             double _during_time;
-            double _linear_velocity = 0.5;  // [m/s]
-            double _sigmoid_gain = 1;
+            double _linear_velocity = 1;  // [m/s]
+            double _sigmoid_gain = 2;
 
         public:
             void setLinearVelocity(const double &linear_velocity_);

--- a/ec_calculator/include/ec_calculator/interpolation.h
+++ b/ec_calculator/include/ec_calculator/interpolation.h
@@ -1,0 +1,41 @@
+#ifndef EC_CALCULATOR_INTERPOLATION_H
+
+#include <iostream>
+#include <chrono>
+
+#include <Eigen/Core>
+#include <Eigen/LU>
+#include <Eigen/Dense>
+#include <Eigen/SVD>
+
+namespace ec_calculator
+{
+    class Interpolation
+    {
+        private:
+            Eigen::Matrix<double, -1, 1> _start_point;
+            Eigen::Matrix<double, -1, 1> _end_point;
+            Eigen::Matrix<double, -1, 1> _mid_point;
+
+            std::chrono::system_clock::time_point _start_time;
+            double _mid_time;
+
+            double _distance;
+            double _during_time;
+            double _linear_velocity = 1;  // [m/s]
+            double _sigmoid_gain = 1;
+
+        public:
+            void setLinearVelocity(const double &linear_velocity_);
+            void setSigmoidGain(const double &sigmoid_gain_);
+            void setPoint(const Eigen::Matrix<double, -1, 1> &start_point_, const Eigen::Matrix<double, -1, 1> &end_point_);
+            double getDistance();
+            double getDuringTime();
+            Eigen::Matrix<double, -1, 1> getLinearInterpolation();
+            Eigen::Matrix<double, -1, 1> getCosInterpolation();
+            Eigen::Matrix<double, -1, 1> getSigmoidInterpolation();
+    };
+}
+
+#define EC_CALCULATOR_INTERPOLATION_H
+#endif

--- a/ec_calculator/include/ec_calculator/manipulator.h
+++ b/ec_calculator/include/ec_calculator/manipulator.h
@@ -23,11 +23,24 @@ namespace ec_calculator
             Eigen::Matrix<double, -1, 1> _target_angle;
             Eigen::Matrix<double, -1, 1> _angular_velocity;
             Eigen::Matrix<double, -1, 1> _target_angular_velocity;
-            int _start_joint = 0, _end_joint = 0;
-            Eigen::Matrix<double, 6, 1> _target_pose;
+
             bool _ec_enable = false;
             bool _emergency_stop = false;
             bool _motor_enable = false;
+
+            // // Inverse Kinematics
+            // std::vector<int> _start_joint_index;
+            int _start_joint_index = 0;
+            // std::vector<int> _end_joint_index;
+            int _end_joint_index = _JOINT_NUM;
+            // std::vector<Eigen::Matrix<double, 6, 1>> _target_pose;
+            // std::vector<Eigen::Matrix<double, 6, 1>> _target_velocity;
+            Eigen::Matrix<double, 6, 1> _target_velocity;
+            // int _ik_index = 0;
+            int _ik_index = 0;
+            Eigen::Matrix<double, -1, -1> _jacobian;
+                // std::vector<Eigen::Matrix<double, 6, -1>> _jacobian_block;
+                Eigen::Matrix<double, 6, -1> _jacobian_block;
 
             // Time
             std::chrono::system_clock::time_point _start_time, _end_time;
@@ -59,14 +72,20 @@ namespace ec_calculator
             Eigen::Matrix<double, -1, 1> getAngle();
             Eigen::Matrix<double, 6, 1> getPose(const int &joint_index_);
 
+            // AC or IK
+            Eigen::Matrix<double, -1, 1> getAngularVelocity();
+
             // Angle Command
             Eigen::Matrix<double, -1, 1> getAngularVelocityByAngle(const Eigen::Matrix<double, -1, 1> &target_angle_);
             Eigen::Matrix<double, -1, 1> getAngularVelocityByAngle();
 
-            // Inverse Kinematics
-            void setJointPosition(const int &start_joint_index_, const int &end_joint_index_, const Eigen::Matrix<double, 6, 1> target_velocity_);
-            void setJointVelocity(const int &start_joint_index_, const int &end_joint_index_, const Eigen::Matrix<double, 6, 1> target_velocity_);
+            // // Inverse Kinematics
+            // void setJointPose(const int &start_joint_index_, const int &end_joint_index_, const Eigen::Matrix<double, 6, 1> &target_pose_);
+            void setJointVelocity(const int &start_joint_index_, const int &end_joint_index_, const Eigen::Matrix<double, 6, 1> &target_velocity_);
+                void clearJointVelocity();
             Eigen::Matrix<double, -1, 1> getAngularVelocityByEC();
+                Eigen::Matrix<double, -1, -1> getJacobian();
+                    Eigen::Matrix<double, 6, -1> getJacobianBlock(const int &ik_index_);
 
             // Angular Velocity to Angle (for Visualization)
             Eigen::Matrix<double, -1, 1> angularVelocity2Angle(const Eigen::Matrix<double, -1, 1> &angular_velocity_);
@@ -77,6 +96,7 @@ namespace ec_calculator
             void setMotorEnable(const bool &motor_enable_);
             void setTargetAngle(const Eigen::Matrix<double, -1, 1> &target_angle_);
             void setTargetPose(const Eigen::Matrix<double, -1, 1> &target_pose_);    // 2: start_joint, end_joint, 6: 3position, 3orientation
+            void setTargetVelocity(const Eigen::Matrix<double, -1, 1> &target_velocity_);
 
             // Debug
             void printTree();

--- a/ec_calculator/include/ec_calculator/manipulator.h
+++ b/ec_calculator/include/ec_calculator/manipulator.h
@@ -2,6 +2,7 @@
 
 #include "model.h"
 #include "joint.h"
+#include "interpolation.h"
 
 #include <chrono>
 
@@ -32,17 +33,16 @@ namespace ec_calculator
             // std::vector<int> _start_joint_index;
             int _start_joint_index = 0;
             // std::vector<int> _end_joint_index;
-            int _end_joint_index = _JOINT_NUM;
+            int _end_joint_index = 1;
             // std::vector<Eigen::Matrix<double, 6, 1>> _target_pose;
-            // std::vector<Eigen::Matrix<double, 6, 1>> _target_velocity;
-            Eigen::Matrix<double, 6, 1> _target_velocity;
-            // int _ik_index = 0;
+            Eigen::Matrix<double, 6, 1> _target_pose;
             int _ik_index = 0;
             Eigen::Matrix<double, -1, -1> _jacobian;
                 // std::vector<Eigen::Matrix<double, 6, -1>> _jacobian_block;
                 Eigen::Matrix<double, 6, -1> _jacobian_block;
 
             // Time
+            Interpolation _interpolation;
             std::chrono::system_clock::time_point _start_time, _end_time;
             double _during_time;
             bool _is_first_time_measurement = true; // TODO: Whether to reset when changing models
@@ -80,9 +80,8 @@ namespace ec_calculator
             Eigen::Matrix<double, -1, 1> getAngularVelocityByAngle();
 
             // // Inverse Kinematics
-            // void setJointPose(const int &start_joint_index_, const int &end_joint_index_, const Eigen::Matrix<double, 6, 1> &target_pose_);
-            void setJointVelocity(const int &start_joint_index_, const int &end_joint_index_, const Eigen::Matrix<double, 6, 1> &target_velocity_);
-                void clearJointVelocity();
+            void setJointPose(const int &start_joint_index_, const int &end_joint_index_, const Eigen::Matrix<double, 6, 1> &target_pose_);
+                void clearJointPose();
             Eigen::Matrix<double, -1, 1> getAngularVelocityByEC();
                 Eigen::Matrix<double, -1, -1> getJacobian();
                     Eigen::Matrix<double, 6, -1> getJacobianBlock(const int &ik_index_);
@@ -101,6 +100,8 @@ namespace ec_calculator
             // Debug
             void printTree();
             void print();
+            Eigen::Matrix<double, 6, 1> getTargetPose();
+            Eigen::Matrix<double, 6, 1> getMidPose();
     };
 }
 

--- a/ec_calculator/include/ec_calculator/manipulator.h
+++ b/ec_calculator/include/ec_calculator/manipulator.h
@@ -29,20 +29,17 @@ namespace ec_calculator
             bool _emergency_stop = false;
             bool _motor_enable = false;
 
-            // // Inverse Kinematics
-            // std::vector<int> _start_joint_index;
-            int _start_joint_index = 0;
-            // std::vector<int> _end_joint_index;
-            int _end_joint_index = 1;
-            // std::vector<Eigen::Matrix<double, 6, 1>> _target_pose;
-            Eigen::Matrix<double, 6, 1> _target_pose;
+            // Inverse Kinematics
             int _ik_index = 0;
+            std::vector<Interpolation> _interpolation;
+            std::vector<int> _start_joint_index;
+            std::vector<int> _end_joint_index;
+            Eigen::Matrix<double, -1, 1> _error_all;
+            std::vector<Eigen::Matrix<double, 6, 1>> _target_pose;
             Eigen::Matrix<double, -1, -1> _jacobian;
-                // std::vector<Eigen::Matrix<double, 6, -1>> _jacobian_block;
-                Eigen::Matrix<double, 6, -1> _jacobian_block;
+                std::vector<Eigen::Matrix<double, 6, -1>> _jacobian_block;
 
             // Time
-            Interpolation _interpolation;
             std::chrono::system_clock::time_point _start_time, _end_time;
             double _during_time;
             bool _is_first_time_measurement = true; // TODO: Whether to reset when changing models
@@ -63,6 +60,7 @@ namespace ec_calculator
             int getJointNum();
             std::string getJointName(const int &joint_index_);
             std::string getJointParentName(const int &joint_index_);
+            int getInverseKinematicsNum();
 
             // Visualize
             double getVisualData(const int &joint_index_, const int &data_index_);
@@ -100,8 +98,8 @@ namespace ec_calculator
             // Debug
             void printTree();
             void print();
-            Eigen::Matrix<double, 6, 1> getTargetPose();
-            Eigen::Matrix<double, 6, 1> getMidPose();
+            Eigen::Matrix<double, 6, 1> getTargetPose(const int &ik_index_);
+            Eigen::Matrix<double, 6, 1> getMidPose(const int &ik_index_);
     };
 }
 

--- a/ec_calculator/src/interpolation.cpp
+++ b/ec_calculator/src/interpolation.cpp
@@ -1,0 +1,71 @@
+#include "ec_calculator/interpolation.h"
+
+namespace ec_calculator
+{
+    void Interpolation::setLinearVelocity(const double &linear_velocity_)
+    {
+        _linear_velocity = linear_velocity_;
+    }
+
+    void Interpolation::setSigmoidGain(const double &sigmoid_gain_)
+    {
+        _sigmoid_gain = sigmoid_gain_;
+    }
+
+    void Interpolation::setPoint(const Eigen::Matrix<double, -1, 1> &start_point_, const Eigen::Matrix<double, -1, 1> &end_point_)
+    {
+        _start_point = start_point_;
+        _end_point = end_point_;
+
+        _distance = getDistance();
+
+        _during_time = getDuringTime();
+
+        _start_time = std::chrono::system_clock::now();
+    }
+
+    double Interpolation::getDistance()
+    {
+        _distance = (_end_point - _start_point).norm();
+
+        return _distance;
+    }
+
+    double Interpolation::getDuringTime()
+    {
+        _during_time = _distance/_linear_velocity;
+
+        return _during_time;
+    }
+
+    Eigen::Matrix<double, -1, 1> Interpolation::getLinearInterpolation()
+    {
+        _mid_time = 0.001 * std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now()-_start_time).count()/_during_time;
+        _mid_time = std::min(std::max((_mid_time), 0.0), 1.0);
+        _mid_point = _start_point * (1 - _mid_time) + _end_point * _mid_time;
+
+        return _mid_point;
+    }
+
+    Eigen::Matrix<double, -1, 1> Interpolation::getCosInterpolation()
+    {
+        _mid_time = 0.001 * std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now()-_start_time).count()/_during_time;
+        _mid_time = std::min(std::max((_mid_time), 0.0), 1.0);
+        _mid_time = (1 - cos(_mid_time * M_PI))/2.0;
+        _mid_point = _start_point * (1 - _mid_time) + _end_point * _mid_time;
+
+        return _mid_point;
+    }
+
+    Eigen::Matrix<double, -1, 1> Interpolation::getSigmoidInterpolation()
+    {
+        _mid_time = 0.001 * std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now()-_start_time).count()/_during_time;
+        _mid_time = std::min(std::max((_mid_time), 0.0), 1.0);
+        double A_ = exp(-_sigmoid_gain*(2*_mid_time-1));
+        double B_ = exp(-_sigmoid_gain);
+        _mid_time = 0.5*(1 + (1-A_)/(1+A_)*(1+B_)/(1-B_));
+        _mid_point = _start_point * (1 - _mid_time) + _end_point * _mid_time;
+
+        return _mid_point;
+    }
+}

--- a/ec_calculator/src/joint.cpp
+++ b/ec_calculator/src/joint.cpp
@@ -119,8 +119,7 @@ namespace ec_calculator
 
     void Joint::setXi()
     {
-        _xi << -_w.cross(_q), _w;
-        // TODO: translation axis ver.
+        _xi << _v, _w;
     }
 
     void Joint::setGstZero()

--- a/ec_calculator/src/joint.cpp
+++ b/ec_calculator/src/joint.cpp
@@ -120,6 +120,7 @@ namespace ec_calculator
     void Joint::setXi()
     {
         _xi << -_w.cross(_q), _w;
+        // TODO: translation axis ver.
     }
 
     void Joint::setGstZero()
@@ -212,6 +213,7 @@ namespace ec_calculator
 
     Eigen::Matrix<double, 4, 4> Joint::getGstTheta()
     {
+        if(_parent == nullptr) return _gst_zero;
         return _parent->getGstThetaRecursion()*_gst_zero;
     }
 
@@ -248,10 +250,12 @@ namespace ec_calculator
 
     Eigen::Matrix<double, 4, 4> Joint::getParentGstTheta(const int &minimum_index_)
     {
+        if(_parent == nullptr) return _gst_zero;
+
         _minimum_index = minimum_index_;
         _parent->_minimum_index = _minimum_index;
 
-        return getParentGstThetaRecursion()*_gst_zero;
+        return _parent->getParentGstThetaRecursion()*_gst_zero;
     }
 
     Eigen::Matrix<double, 4, 4> Joint::getParentGstThetaRecursion()

--- a/ec_calculator/src/manipulator.cpp
+++ b/ec_calculator/src/manipulator.cpp
@@ -229,7 +229,7 @@ namespace ec_calculator
         _error_all.resize(6*_ik_index, 1);
         for(int ik_index = 0; ik_index < _ik_index; ik_index++)
         {
-            _error_all.block(6*ik_index, 0, 6, 1) = _interpolation[ik_index].getCosInterpolation() - getPose(_end_joint_index[ik_index]);
+            _error_all.block(6*ik_index, 0, 6, 1) = _interpolation[ik_index].getSigmoidInterpolation() - getPose(_end_joint_index[ik_index]);
         }
         _target_angular_velocity = EigenUtility.getPseudoInverseMatrix(getJacobian()) * _error_all;
         return _target_angular_velocity;
@@ -252,7 +252,7 @@ namespace ec_calculator
         _jacobian_block[ik_index_].resize(6, _JOINT_NUM);
         _jacobian_block[ik_index_].setZero();
 
-        for(int ik_index = _start_joint_index[ik_index_]; ik_index < _end_joint_index[ik_index_]; ik_index++)
+        for(int ik_index = _start_joint_index[ik_index_]; ik_index < std::min(_end_joint_index[ik_index_], _JOINT_NUM); ik_index++)
         {
             _jacobian_block[ik_index_].block(0, ik_index, 6, 1) = _joints[_end_joint_index[ik_index_]].getXiDagger(ik_index);
         }
@@ -356,7 +356,7 @@ namespace ec_calculator
 
     Eigen::Matrix<double, 6, 1> Manipulator::getMidPose(const int &ik_index_)
     {
-        if(_ec_enable) return _interpolation[ik_index_].getCosInterpolation();
+        if(_ec_enable) return _interpolation[ik_index_].getSigmoidInterpolation();
 
         return Eigen::Matrix<double, 6, 1>::Zero();
     }

--- a/ec_calculator/src/nodes/ec_calculator_node.cpp
+++ b/ec_calculator/src/nodes/ec_calculator_node.cpp
@@ -71,7 +71,7 @@ int main(int argc, char **argv)
     angular_velocity.data.resize(manip.getJointNum());
     target_angle.data.resize(manip.getJointNum());
 
-    // /* New naviT(oo)n
+    // /* New naviT(oo)n */
     // int cha = 1, joi = 8;
     // Eigen::Matrix<bool, 1, 8> cha_ma;
     // for(int i = 0; i < joi; i++)
@@ -104,20 +104,59 @@ int main(int argc, char **argv)
     // manip.print();
     // angular_velocity.data.resize(manip.getJointNum());
     // target_angle.data.resize(manip.getJointNum());
-    // */
 
-    int cha = 1, joi = 30;
-    Eigen::Matrix<bool, 1, 30> cha_ma;
-    for(int i = 0; i < joi; i++)
-    {
-        cha_ma(0, i) = 1;
-    }
-    Eigen::Matrix<double, 3, 31> joi_po;
+    // /* Serial 30-DOF */
+    // int cha = 1, joi = 30;
+    // Eigen::Matrix<bool, 1, 30> cha_ma;
+    // for(int i = 0; i < joi; i++)
+    // {
+    //     cha_ma(0, i) = 1;
+    // }
+    // Eigen::Matrix<double, 3, 31> joi_po;
+    // joi_po.setZero();
+    // for(int i = 4; i < (cha+joi); i++)
+    // {
+    //     joi_po(2,i) = 0.2;
+    // }
+    // Eigen::Matrix<double, 3, 30> tra;
+    // tra.setZero();
+    // tra(0, 0) = 1;
+    // tra(1, 1) = 1;
+    // tra(2, 2) = 1;
+    // Eigen::Matrix<double, 3, 30> rot;
+    // rot.setZero();
+    // for(int i = 3; i < joi; i++)
+    // {
+    //     rot(i%3, i) = 1;
+    // }
+    // Eigen::Matrix<double, 30, 30> a2a_ga;
+    // a2a_ga.setIdentity();
+    // double ec_ga = 2;
+
+    // model.changeModel(cha, joi, cha_ma, joi_po, tra, rot, a2a_ga, ec_ga);
+
+    // manip.init(&model);
+    // manip.printTree();
+    // manip.print();
+    // angular_velocity.data.resize(manip.getJointNum());
+    // target_angle.data.resize(manip.getJointNum());
+
+    /* Chain 30-DOF */
+    int cha = 3, joi = 30;
+    Eigen::Matrix<bool, 3, 30> cha_ma;
+    cha_ma <<
+        //             5                         14             19          23                29
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0,
+        1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1;
+    Eigen::Matrix<double, 3, 33> joi_po;
     joi_po.setZero();
     for(int i = 4; i < (cha+joi); i++)
     {
         joi_po(2,i) = 0.2;
     }
+    joi_po(0, 15) = 0.2;
+    joi_po(0, 24) = 0.2;
     Eigen::Matrix<double, 3, 30> tra;
     tra.setZero();
     tra(0, 0) = 1;

--- a/ec_calculator/src/nodes/ec_calculator_node.cpp
+++ b/ec_calculator/src/nodes/ec_calculator_node.cpp
@@ -44,7 +44,9 @@ void target_angle_cb(std_msgs::Float32MultiArray::ConstPtr msg)
 
 void target_pose_cb(std_msgs::Float32MultiArray::ConstPtr msg)
 {
-    manip.setTargetPose(EigenUtility.array2Matrix(msg->data));
+    // manip.setTargetVelocity(EigenUtility.array2Matrix(msg->data));
+    manip.clearJointVelocity();
+    manip.setTargetVelocity(EigenUtility.array2Matrix(msg->data));
 }
 
 int main(int argc, char **argv)
@@ -71,30 +73,61 @@ int main(int argc, char **argv)
     angular_velocity.data.resize(manip.getJointNum());
     target_angle.data.resize(manip.getJointNum());
 
-    int cha = 4, joi = 7;
-    Eigen::Matrix<bool, 4, 7> cha_ma;
+    // int cha = 4, joi = 7;
+    // Eigen::Matrix<bool, 4, 7> cha_ma;
+    // cha_ma <<
+    // // 1  2  3  4  5  6  7  8  9 10
+    // 1, 1, 1, 1, 0, 0, 0,
+    // 1, 1, 1, 0, 1, 0, 0,
+    // 1, 0, 0, 0, 0, 1, 0,
+    // 1, 0, 0, 0, 0, 0, 1;
+    // Eigen::Matrix<double, 3, 11> joi_po;
+    // joi_po <<
+    // 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    // 0, 0, 0, 0, 1, 2, 3, 0, 0, 0, 0,
+    // 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
+    // Eigen::Matrix<double, 3, 7> tra;
+    // tra.setZero();
+    // Eigen::Matrix<double, 3, 7> rot;
+    // rot <<
+    // 0, 0, 0, 1, 0, 0, 0,
+    // 0, 1, 0, 0, 0, 1, 0,
+    // 1, 0, 1, 0, 1, 0, 1;
+    // Eigen::Matrix<double, 7, 7> a2a_ga;
+    // a2a_ga.setIdentity();
+    // a2a_ga *= 2.0;
+    // double ec_ga = 2.0;
+
+    // model.changeModel(cha, joi, cha_ma, joi_po, tra, rot, a2a_ga, ec_ga);
+
+    // manip.init(&model);
+    // manip.printTree();
+    // manip.print();
+    // angular_velocity.data.resize(manip.getJointNum());
+    // target_angle.data.resize(manip.getJointNum());
+
+    int cha = 2, joi = 9;
+    Eigen::Matrix<bool, 2, 9> cha_ma;
     cha_ma <<
     // 1  2  3  4  5  6  7  8  9 10
-    1, 1, 1, 1, 0, 0, 0,
-    1, 1, 1, 0, 1, 0, 0,
-    1, 0, 0, 0, 0, 1, 0,
-    1, 0, 0, 0, 0, 0, 1;
+    1, 1, 1, 1, 1, 1, 1, 1, 0,
+    1, 1, 1, 1, 1, 1, 0, 0, 1;
     Eigen::Matrix<double, 3, 11> joi_po;
     joi_po <<
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    0, 0, 0, 0, 1, 2, 3, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
-    Eigen::Matrix<double, 3, 7> tra;
+    Eigen::Matrix<double, 3, 9> tra;
     tra.setZero();
-    Eigen::Matrix<double, 3, 7> rot;
+    Eigen::Matrix<double, 3, 9> rot;
     rot <<
-    0, 0, 0, 1, 0, 0, 0,
-    0, 1, 0, 0, 0, 1, 0,
-    1, 0, 1, 0, 1, 0, 1;
-    Eigen::Matrix<double, 7, 7> a2a_ga;
+    0, 0, 0, 1, 0, 0, 0, 0, 0,
+    0, 1, 0, 0, 0, 1, 0, 1, 0,
+    1, 0, 1, 0, 1, 0, 1, 0, 1;
+    Eigen::Matrix<double, 9, 9> a2a_ga;
     a2a_ga.setIdentity();
     a2a_ga *= 2.0;
-    double ec_ga = 2.0;
+    double ec_ga = 0.1;
 
     model.changeModel(cha, joi, cha_ma, joi_po, tra, rot, a2a_ga, ec_ga);
 
@@ -108,9 +141,9 @@ int main(int argc, char **argv)
     {
         tfPublisher.publish();
 
-        manip.angularVelocity2Angle(manip.getAngularVelocityByAngle());    // callBack(){manip.setAngle(msg);} while(){pub.publish(manip.getAngularVelocity());}
+        manip.angularVelocity2Angle(manip.getAngularVelocity());    // callBack(){manip.setAngle(msg);} while(){pub.publish(manip.getAngularVelocity());}
 
-        angular_velocity.data = EigenUtility.matrix2Array(manip.getAngularVelocityByAngle());
+        angular_velocity.data = EigenUtility.matrix2Array(manip.getAngularVelocity());
         angular_velocity_pub.publish(angular_velocity);
 
         manip.print();

--- a/ec_calculator/src/nodes/ec_calculator_node.cpp
+++ b/ec_calculator/src/nodes/ec_calculator_node.cpp
@@ -44,7 +44,6 @@ void target_angle_cb(std_msgs::Float32MultiArray::ConstPtr msg)
 
 void target_pose_cb(std_msgs::Float32MultiArray::ConstPtr msg)
 {
-    manip.clearJointPose();
     manip.setTargetPose(EigenUtility.array2Matrix(msg->data));
 }
 
@@ -72,30 +71,67 @@ int main(int argc, char **argv)
     angular_velocity.data.resize(manip.getJointNum());
     target_angle.data.resize(manip.getJointNum());
 
-    int cha = 1, joi = 8;
-    Eigen::Matrix<bool, 1, 8> cha_ma;
+    // /* New naviT(oo)n
+    // int cha = 1, joi = 8;
+    // Eigen::Matrix<bool, 1, 8> cha_ma;
+    // for(int i = 0; i < joi; i++)
+    // {
+    //     cha_ma(0, i) = 1;
+    // }
+    // Eigen::Matrix<double, 3, 9> joi_po;
+    // joi_po <<
+    //     0, 0, 0, 0.01, 0.030,  0.030, 0,  0    , 0,
+    //     0, 0, 0, 0   , 0.264, -0.258, 0,  0    , 0,
+    //     0, 0, 0, 0   , 0    ,  0,     0, -0.123, 0;
+    // Eigen::Matrix<double, 3, 8> tra;
+    // tra.setZero();
+    // tra(0, 0) = 1;
+    // tra(1, 1) = 1;
+    // tra(2, 2) = 1;
+    // Eigen::Matrix<double, 3, 8> rot;
+    // rot <<
+    //     0, 0, 0,  0,  0,  0, 1,  0,
+    //     0, 0, 0,  0,  0, -1, 0,  0,
+    //     0, 0, 0, -1, -1,  0, 0, -1;
+    // Eigen::Matrix<double, 8, 8> a2a_ga;
+    // a2a_ga.setIdentity();
+    // double ec_ga = 1;
+
+    // model.changeModel(cha, joi, cha_ma, joi_po, tra, rot, a2a_ga, ec_ga);
+
+    // manip.init(&model);
+    // manip.printTree();
+    // manip.print();
+    // angular_velocity.data.resize(manip.getJointNum());
+    // target_angle.data.resize(manip.getJointNum());
+    // */
+
+    int cha = 1, joi = 30;
+    Eigen::Matrix<bool, 1, 30> cha_ma;
     for(int i = 0; i < joi; i++)
     {
         cha_ma(0, i) = 1;
     }
-    Eigen::Matrix<double, 3, 9> joi_po;
-    joi_po <<
-        0, 0, 0, 0.01, 0.030,  0.030, 0,  0    , 0,
-        0, 0, 0, 0   , 0.264, -0.258, 0,  0    , 0,
-        0, 0, 0, 0   , 0    ,  0,     0, -0.123, 0;
-    Eigen::Matrix<double, 3, 8> tra;
+    Eigen::Matrix<double, 3, 31> joi_po;
+    joi_po.setZero();
+    for(int i = 4; i < (cha+joi); i++)
+    {
+        joi_po(2,i) = 0.2;
+    }
+    Eigen::Matrix<double, 3, 30> tra;
     tra.setZero();
     tra(0, 0) = 1;
     tra(1, 1) = 1;
     tra(2, 2) = 1;
-    Eigen::Matrix<double, 3, 8> rot;
-    rot <<
-        0, 0, 0,  0,  0,  0, 1,  0,
-        0, 0, 0,  0,  0, -1, 0,  0,
-        0, 0, 0, -1, -1,  0, 0, -1;
-    Eigen::Matrix<double, 8, 8> a2a_ga;
+    Eigen::Matrix<double, 3, 30> rot;
+    rot.setZero();
+    for(int i = 3; i < joi; i++)
+    {
+        rot(i%3, i) = 1;
+    }
+    Eigen::Matrix<double, 30, 30> a2a_ga;
     a2a_ga.setIdentity();
-    double ec_ga = 1;
+    double ec_ga = 2;
 
     model.changeModel(cha, joi, cha_ma, joi_po, tra, rot, a2a_ga, ec_ga);
 
@@ -108,8 +144,11 @@ int main(int argc, char **argv)
     while(nh.ok())
     {
         tfPublisher.publish();
-        tfPublisher.publish("manipulator_base_link", "TargetPose", manip.getTargetPose());
-        tfPublisher.publish("manipulator_base_link", "MidTargetPose", manip.getMidPose());
+        for(int i = 0; i < manip.getInverseKinematicsNum(); i++)
+        {
+            tfPublisher.publish("manipulator_base_link", "TargetPose"+std::to_string(i), manip.getTargetPose(i));
+            tfPublisher.publish("manipulator_base_link", "MidTargetPose"+std::to_string(i), manip.getMidPose(i));
+        }
 
         manip.angularVelocity2Angle(manip.getAngularVelocity());    // callBack(){manip.setAngle(msg);} while(){pub.publish(manip.getAngularVelocity());}
 


### PR DESCRIPTION
### 逆運動学
- 目標 ( start_joint，end_joint，target_pose ) の指令を司令して，逆運動学を解きます．
- end_joint が target_pose に動くように start_joint 〜 end_joint を動かします．
- 目標をいくつか設定して，それらを同時に達成するように逆運動学を解くことができます．
- 目標を複数持つため， start_joint，end_joint，target_pose，jacobian_block を std::vector にしました．

### 補完
- なめらかな動きにするために補完クラス Interpoaltion を作成しました．
- 直線補完，cos補完，シグモイド補完を使用できます．